### PR TITLE
feat: initialize nix flake for project

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# https://github.com/nix-community/nix-direnv?tab=readme-ov-file#flakes-support
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# direnv cache folder
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1680978846,
+        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  inputs = {
+    # Externally extensible flake systems
+    systems.url = "github:nix-systems/x86_64-linux";
+
+    # Nix Packages collection & NixOS
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    # Pure Nix flake utility functions
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.systems.follows = "systems";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }: let
+    inherit (nixpkgs.lib) genAttrs;
+    inherit (flake-utils.lib) defaultSystems;
+
+    # Create attribute set of default systems from flake-utils
+    genAttrsFromDefaultSystems = genAttrs defaultSystems;
+
+    # Extended Nixpkgs collection with additional and modified packages
+    legacyPackages = genAttrsFromDefaultSystems (system:
+      import nixpkgs {
+        inherit system;
+      });
+  in {
+    # Run a bash shell that provides the development environment
+    # Usage: `nix develop`
+    devShells = genAttrsFromDefaultSystems (system: import ./shell.nix {pkgs = legacyPackages.${system};});
+
+    # Reformat code in the standard style
+    # Usage: `nix fmt`
+    formatter = genAttrsFromDefaultSystems (system: legacyPackages.${system}.alejandra);
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{pkgs}: {
+  default = pkgs.mkShell {
+    # List of packages to add to the shell environment
+    packages = with pkgs; [
+      nodejs
+    ];
+  };
+}


### PR DESCRIPTION
Initialize Nix Flake configuration for project using `nix flake init`.

This declaratively defines the development environment for this project by explicitly mentioning the requires dependencies to run the program (in the 'shell.nix' file) as well as locking those dependencies to a consistent version across devices (using the 'flake.lock' file).

Additionally, automatically trigger the enabling of this developer environment using nix-direnv to trigger `nix develop` upon entering the project directory. This is done through the '.envrc' file and requires that nix-direnv is installed on the system.