### PR TITLE
fix: give vercel access to db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build output
 dist/
+.vercel/
 
 # generated types
 .astro/

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
-    "preview": "astro preview",
+    "build": "astro check && astro build --remote",
     "astro": "astro"
   },
   "dependencies": {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/db-types.d.ts" />
 /// <reference types="astro/client" />


### PR DESCRIPTION
Configure Vercel to have access to the database in Astro Studio. Give access during build using the `--remote` flag in the `astro build` command. Also provide the ASTRO_STUDIO_APP_TOKEN to the Vercel environment variables list in order to give read/write access.